### PR TITLE
v0 Performance Improvements

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,7 +1,11 @@
 import Head from 'next/head'
-import Footer from '@/components/navigation/footer'
-import Header from '@/components/navigation/header'
+import dynamic from 'next/dynamic'
 import { Box, Container } from '@chakra-ui/react'
+import Header from '@/components/navigation/header'
+
+const DynamicFooter = dynamic(() => import('@/components/navigation/footer'), {
+  ssr: false
+})
 
 type Props = {
   children: React.ReactNode
@@ -46,7 +50,8 @@ export default function Layout(props: Props) {
             {props.children}
           </Container>
         </Box>
-        <Footer />
+        {/* Load footer dynamically to attempt to realize a perf gain  */}
+        <DynamicFooter />
       </Box>
     </>
   )

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head'
 import dynamic from 'next/dynamic'
-import { Box, Container } from '@chakra-ui/react'
 import Header from '@/components/navigation/header'
+import { Box, Container } from '@chakra-ui/react'
 
 const DynamicFooter = dynamic(() => import('@/components/navigation/footer'), {
   ssr: false

--- a/components/top_of_page_button.tsx
+++ b/components/top_of_page_button.tsx
@@ -1,0 +1,39 @@
+import { ChevronUpIcon } from '@chakra-ui/icons'
+import { useState, useEffect, useRef } from 'react'
+import { IconButton } from '@chakra-ui/react'
+
+interface Props {
+  scrollUp: () => void
+}
+
+export default function TopOfPageButton(props: Props) {
+  const [showScrollToTop, setShowScrollToTop] = useState(false)
+  useEffect(() => {
+    const handleVisibleButton = () => {
+      const position = window.pageYOffset
+      if (position > 100) {
+        return setShowScrollToTop(true)
+      } else if (position < 100) {
+        return setShowScrollToTop(false)
+      }
+    }
+
+    window.addEventListener('scroll', handleVisibleButton)
+  })
+
+  return (
+    <>
+      {/* TODO: look into providing a custom hook to fix this type error: https://stackoverflow.com/a/64151312/8168077*/}
+      {showScrollToTop && (
+        <IconButton
+          position="fixed"
+          bottom="8%"
+          right="8%"
+          onClick={props.scrollUp}
+          aria-label="Go to top of page"
+          icon={<ChevronUpIcon />}
+        />
+      )}
+    </>
+  )
+}

--- a/components/top_of_page_button.tsx
+++ b/components/top_of_page_button.tsx
@@ -23,7 +23,6 @@ export default function TopOfPageButton(props: Props) {
 
   return (
     <>
-      {/* TODO: look into providing a custom hook to fix this type error: https://stackoverflow.com/a/64151312/8168077*/}
       {showScrollToTop && (
         <IconButton
           position="fixed"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,15 +1,12 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useRef } from 'react'
+import dynamic from 'next/dynamic'
 import { AppProps } from 'next/app'
 import { useRouter } from 'next/router'
 import Script from 'next/script'
-import {
-  ChakraProvider,
-  extendTheme,
-  IconButton,
-  type ThemeConfig
-} from '@chakra-ui/react'
-import { ChevronUpIcon } from '@chakra-ui/icons'
+import { ChakraProvider, extendTheme, type ThemeConfig } from '@chakra-ui/react'
 import * as ga from '@/lib/ga'
+
+const TopOfPageButton = dynamic(() => import('@/components/top_of_page_button'))
 
 const config: ThemeConfig = {
   initialColorMode: 'system',
@@ -17,13 +14,12 @@ const config: ThemeConfig = {
 }
 
 export default function Application({ Component, pageProps }: AppProps) {
-  const [showScrollToTop, setShowScrollToTop] = useState(false)
-  const refScrollUp = useRef<HTMLDivElement>()
   const router = useRouter()
+  const refScrollUp = useRef<HTMLDivElement>()
 
-  useEffect(() => {
-    window.addEventListener('scroll', handleVisibleButton)
-  })
+  const handleScrollUp = () => {
+    refScrollUp.current?.scrollIntoView({ behavior: 'smooth' })
+  }
 
   useEffect(() => {
     const handleRouteChange = (url: string) => {
@@ -40,19 +36,6 @@ export default function Application({ Component, pageProps }: AppProps) {
       router.events.off('routeChangeComplete', handleRouteChange)
     }
   }, [router.events])
-
-  const handleVisibleButton = () => {
-    const position = window.pageYOffset
-    if (position > 100) {
-      return setShowScrollToTop(true)
-    } else if (position < 100) {
-      return setShowScrollToTop(false)
-    }
-  }
-
-  const handleScrollUp = () => {
-    refScrollUp?.current?.scrollIntoView({ behavior: 'smooth' })
-  }
 
   return (
     <>
@@ -75,18 +58,10 @@ export default function Application({ Component, pageProps }: AppProps) {
         }}
       />
       <ChakraProvider theme={extendTheme({ config })}>
-        {/* TODO: look into providing a custom hook to fix this type error: https://stackoverflow.com/a/64151312/8168077*/}
+        {/* TODO: look into providing a custom hook to fix this type error: https://stackoverflow.com/a/64151312/8168077.
+        This is why we case the type here. */}
         <div ref={refScrollUp as React.RefObject<HTMLDivElement>}></div>
-        {showScrollToTop && (
-          <IconButton
-            position="fixed"
-            bottom="8%"
-            right="8%"
-            onClick={handleScrollUp}
-            aria-label="Go to top of page"
-            icon={<ChevronUpIcon />}
-          />
-        )}
+        <TopOfPageButton scrollUp={handleScrollUp} />
         <Component {...pageProps} />
       </ChakraProvider>
     </>


### PR DESCRIPTION
- Dynamic load footer onto page as it is not needed until the user scrolls
   - Saw CLS with dynamic on header. This can be fixed by reserving height for the header but is likely overkill for now
- Move scroll to top code to own component that is lazy loaded as it is not needing during page load  

## Bundle size diff

### Before
<img width="582" alt="Screen Shot 2022-12-23 at 7 18 41 PM" src="https://user-images.githubusercontent.com/6364440/209414944-912cd219-c964-4b7c-be64-a9785cd1319b.png">

### After
<img width="582" alt="Screen Shot 2022-12-23 at 7 16 30 PM" src="https://user-images.githubusercontent.com/6364440/209414967-0671fda4-fbad-4616-8b61-adbe59dac9fb.png">